### PR TITLE
Enhance max length of item_list parameter. #2

### DIFF
--- a/long2wide/README.md
+++ b/long2wide/README.md
@@ -44,7 +44,7 @@ OVER ( PARTITION BY expression[,…] )
 ### Parameters
 |Parameter name|Set to...|
 |--|--|
-|item_list|Comma-separated observations to be displayed as columns. Maximum length is 65000.|
+|item_list|Comma-separated observations to be displayed as columns. Maximum length is 32,000,000.|
 |PARTITION BY _expression_|Expression on which to divides the rows of the function input. Expression has to be the same as the expression specified before Long2Wide function in SELECT clause.|
 
 ### Examples
@@ -108,4 +108,4 @@ To install Long2Wide function, run the following statement in vsql:
 
 ### Notes
 
-Long2Wide function has been tested in Vertica 11.0.0.
+Long2Wide function has been tested in Vertica 11.0.1.

--- a/long2wide/long2wide.cpp
+++ b/long2wide/long2wide.cpp
@@ -20,8 +20,9 @@
 using namespace Vertica;
 
 const std::string ITEM_LIST = "item_list"; // parameter name for item list
-const int ITEM_LIST_MAX_LEN = 65000; // maximum length for item_list parameter
-const std::string DEBUG = "debug";   // parameter name for debug flag
+const int ITEM_LIST_MAX_LEN
+    = 32000000;                            // maximum length for item_list parameter
+const std::string DEBUG = "debug";         // parameter name for debug flag
 
 const std::string ITEM_COLUMN = "item_column"; // argument name for item column
 const std::string VALUE_COLUMN
@@ -507,7 +508,7 @@ public:
         using Properties = SizedColumnTypes::Properties;
         // Define item_list parameter.
         {
-            parameterTypes.addVarchar(
+            parameterTypes.addLongVarchar(
                 ITEM_LIST_MAX_LEN, ITEM_LIST,
                 Properties(true /* visible */, true /* required */,
                            false /* canBeNull */,


### PR DESCRIPTION
Enhance the max length of item_list parameter. The original max length was the same as the max length of VARCHAR data type which was 65000. Now it is 32000000 that is the max length of LONG VARCHAR data type. Close #2