### PR TITLE
Add functionality to store malloc_info output into a file

### DIFF
--- a/mallocinfo/README.md
+++ b/mallocinfo/README.md
@@ -9,14 +9,22 @@ This function is used as the debug purpose. Vertica triggers malloc_trim() syste
 ### Syntax
 
 ```
-MALLOCINFO ()
+MALLOCINFO ( { ['output_filename'] | null } )
 ```
 
 ### Examples
 
+1. Store the output of malloc_info() into UDX_EVENTS system table
+
 ```
-=> SELECT mallocinfo();
+=> SELECT mallocinfo(null);
 => SELECT __RAW__['mallocinfo'] FROM udx_events WHERE session_id = current_session();
+```
+
+2. Store the output of malloc_info() into a file
+
+```
+=> SELECT mallocinfo('/tmp/mallocinfo.txt');
 ```
 
 ### Installation

--- a/mallocinfo/mallocinfo.cpp
+++ b/mallocinfo/mallocinfo.cpp
@@ -8,6 +8,9 @@
  */
 #include "Vertica.h"
 #include <malloc.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
 
 using namespace Vertica;
 
@@ -24,16 +27,40 @@ class MallocInfo : public ScalarFunction
     void
     processBlock(ServerInterface &srvInterface, BlockReader &argReader, BlockWriter &resWriter)
     {
-        char *buf;
-        size_t size;
-        FILE *fp = open_memstream(&buf, &size);
-        malloc_info(0, fp);
-        fclose(fp);
-        std::map<std::string, std::string> details;
-        details["mallocinfo"] = buf;
-        srvInterface.logEvent(details);
-        free(buf);
-        resWriter.setInt(0);
+        int returnValue = 0;
+
+        // Store the output of malloc_info to UDX_EVENTS
+        if (argReader.isNull(0) == true) {
+            char *buf;
+            size_t size;
+            FILE *fp = open_memstream(&buf, &size);
+            returnValue = malloc_info(0, fp);
+            fclose(fp);
+            std::map<std::string, std::string> details;
+            details["mallocinfo"] = buf;
+            srvInterface.logEvent(details);
+            free(buf);
+        }
+        // Store the output of malloc_info to a file specified by the user
+        else {
+            VString inputValue = argReader.getStringRef(0);
+            std::string filename = inputValue.str();
+            if (access(filename.c_str(), F_OK) == 0) {
+                vt_report_error(0, "File [%s] already exists", filename.c_str());
+            } else {
+                FILE *fp = fopen(filename.c_str(), "w");
+                if (fp == NULL) {
+                    vt_report_error(0, "Failed to open %s file [%s]", filename.c_str(), strerror(errno));
+                }
+                returnValue = malloc_info(0, fp);
+                fclose(fp);
+            }
+        }
+
+        if (returnValue != 0) {
+            vt_report_error(0, "Failed to get malloc info");
+        }
+        resWriter.setInt(returnValue);
         resWriter.next();
     }
 };
@@ -46,6 +73,7 @@ class MallocInfoFactory : public ScalarFunctionFactory
     void
     getPrototype(ServerInterface &srvInterface, ColumnTypes &argTypes, ColumnTypes &returnType)
     {
+        argTypes.addVarchar();
         returnType.addInt();
     }
 


### PR DESCRIPTION
To solve the issue that it cannot store the output in UDX_EVENTS system table, add functionality to store it into an external file. Close #11