### PR TITLE
Fix the issue that return value is always zero when one item is specified in item_list

### DIFF
--- a/long2wide/Makefile
+++ b/long2wide/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Hibiki Serizawa
+# Copyright (c) 2024-2025 Hibiki Serizawa
 #
 # Description: Makefile to build long2wide function
 #

--- a/long2wide/install.sql
+++ b/long2wide/install.sql
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Hibiki Serizawa
+ * Copyright (c) 2024-2025 Hibiki Serizawa
  *
  * Description: SQL script to install long2wide
  *

--- a/long2wide/long2wide.cpp
+++ b/long2wide/long2wide.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Hibiki Serizawa
+ * Copyright (c) 2024-2025 Hibiki Serizawa
  *
  * Description: Long2Wide : Transform the long-form data into the wide-form data
  *
@@ -500,13 +500,16 @@ private:
                     last = itemListSize;
                 }
             }
-            itemsSize = items.size();
+        } else {
+            items.resize(1);
+            items[0] = itemList;
+        }
+        itemsSize = items.size();
 
-            if (debugFlag == vbool_true) {
-                debugLog(srvInterface, "  Number of items is [%d]", itemsSize);
-                for (int i = 0; i < itemsSize; i++) {
-                    debugLog(srvInterface, "    items[%d] is [%s]", i, items[i].c_str());
-                }
+        if (debugFlag == vbool_true) {
+            debugLog(srvInterface, "  Number of items is [%d]", itemsSize);
+            for (int i = 0; i < itemsSize; i++) {
+                debugLog(srvInterface, "    items[%d] is [%s]", i, items[i].c_str());
             }
         }
     }
@@ -645,7 +648,7 @@ public:
         } else {
             vt_report_error(0,
                             "%s parameter or %s parameter has to be provided",
-                            ITEM_LIST, ITEM_RANGE_MAX);
+                            ITEM_LIST.c_str(), ITEM_RANGE_MAX.c_str());
         }
     }
 

--- a/long2wide/sqltest/long2wide_test.sql
+++ b/long2wide/sqltest/long2wide_test.sql
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Hibiki Serizawa
+ * Copyright (c) 2024-2025 Hibiki Serizawa
  *
  * Description: SQL script to test long2wide
  *

--- a/long2wide/uninstall.sql
+++ b/long2wide/uninstall.sql
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Hibiki Serizawa
+ * Copyright (c) 2024-2025 Hibiki Serizawa
  *
  * Description: SQL script to uninstall long2wide
  *


### PR DESCRIPTION
The cause was that it didn't pick up the item from the list when it didn't contain ',' character which meant there was only one item in it. Close #19.